### PR TITLE
Update schedule for database update job

### DIFF
--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -10,8 +10,8 @@ on:
   workflow_dispatch:
 
   schedule:
-    # Run the job every day at 12:00 AM UTC
-    - cron: '0 0 * * *'
+    # Run the job every day at 01:00 AM UTC
+    - cron: '0 1 * * *'
 
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
this ensures the database refresh job runs after [data-collection job](https://github.com/carbonplan/offsets-db-download/blob/54412a9d25090e9c833617e8b6aef1c0758f7f67/.github/workflows/data-collection.yaml#L17) (which runs every day at 00:00 AM UTC)