### PR TITLE
split fly.yml into two jobs

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -31,15 +31,42 @@ env:
   STAGING_URL: 'https://offsets-db-staging.fly.dev/docs'
 
 jobs:
-  deploy:
-    name: deploy app
+  deploy-staging:
+    name: deploy staging
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment:
-      name: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
-      url: ${{ github.ref == 'refs/heads/main' && env.PRODUCTION_URL || env.STAGING_URL }}
-
+      name: staging
+      url: ${{ env.STAGING_URL }}
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'api') && github.event_name == 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'}}
+    steps:
+      - uses: actions/checkout@v6
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::631969445205:role/github-action-role
+          role-session-name: offsets-db-fly-role-session
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.9.5
+        with:
+          cache: true
+          locked: true
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - name: Deploy to Staging
+        run: |
+          flyctl deploy --remote-only --config fly.staging.toml
+          pixi run update-db-staging
+
+  deploy-production:
+    name: deploy production
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: deploy-staging
+    environment:
+      name: production
+      url: ${{ env.PRODUCTION_URL }}
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
     steps:
       - uses: actions/checkout@v6
       - name: configure aws credentials
@@ -57,20 +84,12 @@ jobs:
         with:
           cache: true
           locked: true
-
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - name: Deploy to Staging
-        run: |
-          flyctl deploy --remote-only --config fly.staging.toml
-          pixi run update-db-staging
-
       - name: Deploy to Production
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         run: |
           flyctl deploy --remote-only --config fly.prod.toml
-
       - name: Notify Slack on Failure
-        if: failure() && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
+        if: failure()
         uses: slackapi/slack-github-action@v3.0.1
         with:
           method: chat.postMessage
@@ -115,8 +134,6 @@ jobs:
                 }
               ]
             }
-
       - name: Update Production DB
-        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         run: |
           pixi run update-db-production

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Upload code coverage to Codecov
         uses: codecov/codecov-action@v6.0.0
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           env_vars: OS,PYTHON
           name: codecov-umbrella

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 OffsetsDB-API, is a fastAPI application, designed to integrate and harmonize data related to the issuance and use of offset credits from the six major offset registries. This database aims to promote transparency and accountability in the carbon offsets market. It provides an accessible online tool, data downloads, and APIs for researchers, journalists, and regulators.
 
 [![Fly.io Deployment](https://github.com/carbonplan/offsets-db-api/actions/workflows/fly.yml/badge.svg)](https://github.com/carbonplan/offsets-db-api/actions/workflows/fly.yml)
-[![Database Update](https://github.com/carbonplan/offsets-db-api/actions/workflows/update-db.yaml/badge.svg)](https://github.com/carbonplan/offsets-db-api/actions/workflows/updated-db.yaml)
+[![Database Update](https://github.com/carbonplan/offsets-db-api/actions/workflows/update-db.yaml/badge.svg)](https://github.com/carbonplan/offsets-db-api/actions/workflows/update-db.yaml)
 ![MIT License](https://badgen.net/badge/license/MIT/blue)
 [![Code Coverage Status][codecov-badge]][codecov-link]
 


### PR DESCRIPTION
- deploy-staging runs on PR (labeled api), push to main, or workflow_dispatch. Deploys staging + runs update-db-staging.
- deploy-production needs: deploy-staging, only runs on push to main or workflow_dispatch. deploys prod, notifies Slack on failure, runs update-db-production.