### PR TITLE
fix `tags` ARRAY column

### DIFF
--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -1,12 +1,6 @@
 name: Update DB
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
   repository_dispatch:
     types: [update-db] # This is the event type we'll trigger from the API. It is currently used in carbonplan/offsets-db-download/.github/workflows

--- a/offsets_db_api/tasks.py
+++ b/offsets_db_api/tasks.py
@@ -1,6 +1,7 @@
 import csv
 import datetime
 import io
+import json
 import random
 import time
 import traceback
@@ -179,13 +180,23 @@ def process_dataframe(
         for col_name, dtype in dtype_dict.items():
             if 'ARRAY' in str(dtype) and col_name in df.columns:
                 logger.info(f'Converting column {col_name} to PostgreSQL array format')
-                df[col_name] = df[col_name].apply(
-                    lambda x: (
-                        '{' + ','.join(str(i) for i in x) + '}'
-                        if (hasattr(x, '__iter__') and not isinstance(x, str))
-                        else x
-                    )
-                )
+
+                def _to_pg_array(x):
+                    if x is None:
+                        return x
+                    if isinstance(x, str):
+                        try:
+                            parsed = json.loads(x)
+                            if isinstance(parsed, list):
+                                return '{' + ','.join(str(i) for i in parsed) + '}'
+                        except (json.JSONDecodeError, ValueError):
+                            pass
+                        return x
+                    if hasattr(x, '__iter__'):
+                        return '{' + ','.join(str(i) for i in x) + '}'
+                    return x
+
+                df[col_name] = df[col_name].apply(_to_pg_array)
 
     with engine.begin() as conn:
         if table_name == 'credit':
@@ -525,6 +536,11 @@ async def process_files(*, engine, session, files: list[File], chunk_size: int =
     for _, row in df.iterrows():
         clip_id = row['id']  # Assuming 'id' is the primary key in Clip model
         project_ids = row['project_ids']
+        if isinstance(project_ids, str):
+            try:
+                project_ids = json.loads(project_ids)
+            except (json.JSONDecodeError, ValueError):
+                project_ids = [project_ids]
         for project_id in project_ids:
             clip_projects_data.append({'id': index, 'clip_id': clip_id, 'project_id': project_id})
             index += 1

--- a/pixi.lock
+++ b/pixi.lock
@@ -3975,8 +3975,8 @@ packages:
   timestamp: 1763350930747
 - pypi: ./
   name: offsets-db-api
-  version: 999.post186+g04a89435f.d20260420
-  sha256: 4bfcc770d3aedab09fb9f5e70c2677d80755152c3391cb3ee89c9a53ae459cd0
+  version: 999.post187+g9480e1600.d20260420
+  sha256: 1cf1afa91b26a377dfac56d8a69c604d06a0ffcc769aa7003e21864f5d483bcc
   requires_dist:
   - fastapi-cache2 @ git+https://github.com/andersy005/fastapi-cache@pydantic-v2-compat
   - offsets-db-data @ git+https://github.com/carbonplan/offsets-db-data.git@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,8 +134,12 @@
     db-down        = "docker compose down"
     db-logs        = "docker compose logs -f db"
     db-up          = "docker compose up -d --wait db"
+    # Wipe data volumes and start a completely fresh DB (WARNING: destroys all local data).
+    db-reset = "docker compose down -v && docker compose up -d --wait db"
     # Start DB, wait until healthy, then apply migrations (one-time setup or after a schema change).
     dev-setup = { depends-on = ["db-up", "migrate"] }
+    # Wipe DB, recreate, and apply migrations — use when the schema is broken or migrations are out of sync.
+    dev-reset = { depends-on = ["db-reset", "migrate"] }
     # Start DB then launch the dev server (daily startup).
     dev = { depends-on = ["db-up", "serve"] }
 
@@ -149,6 +153,8 @@
     # ── Database updates ──────────────────────────────────────────────────────
     update-db-production = "python scripts/update_database.py production --url https://offsets-db.fly.dev/files/"
     update-db-staging    = "python scripts/update_database.py staging --url https://offsets-db-staging.fly.dev/files/"
+    # Seed local DB from staging-files.json (requires `pixi run serve` to be running in another terminal).
+    seed-local = "OFFSETS_DB_API_KEY_STAGING=local-dev-key python scripts/update_database.py staging --url http://127.0.0.1:8000/files/"
 
     # ── Load testing ──────────────────────────────────────────────────────────
     loadtest = "locust -f load-testing/locustfile.py"

--- a/scripts/update_database.py
+++ b/scripts/update_database.py
@@ -86,15 +86,15 @@ def _get_api_key(env: str) -> str:
     return key
 
 
-def _request(method: str, url: str, headers: dict, **kwargs) -> httpx.Response:
+def _request(method: str, url: str, headers: dict, timeout: float = 30, **kwargs) -> httpx.Response:
     try:
-        return httpx.request(method, url, headers=headers, timeout=30, **kwargs)
+        return httpx.request(method, url, headers=headers, timeout=timeout, **kwargs)
     except httpx.ConnectError:
         print(f'Error: could not connect to {url}')
         print('Is the API server running?')
         sys.exit(1)
     except httpx.TimeoutException:
-        print(f'Error: request to {url} timed out after 30s')
+        print(f'Error: request to {url} timed out after {timeout:.0f}s')
         sys.exit(1)
 
 
@@ -147,6 +147,7 @@ def post_data_to_environment(
     env: str,
     url: str,
     files: list[dict[str, str]],
+    post_timeout: float = 120,
 ) -> None:
     headers = {
         'accept': 'application/json',
@@ -158,9 +159,9 @@ def post_data_to_environment(
     for file in files:
         print(f'- {file["category"]}: {file["url"]}')
 
-    response = _request('POST', url, headers=headers, json=files)
+    response = _request('POST', url, headers=headers, json=files, timeout=post_timeout)
     if not response.is_success:
-        print(f'\nFailed in {env}: HTTP {response.status_code} {response.reason}')
+        print(f'\nFailed in {env}: HTTP {response.status_code} {response.reason_phrase}')
         if body := response.text.strip():
             print(body)
         sys.exit(1)

--- a/scripts/update_database.py
+++ b/scripts/update_database.py
@@ -3,10 +3,11 @@ import datetime
 import json
 import os
 import sys
+import time
 
 import fsspec
+import httpx
 import pandas as pd
-import requests
 
 
 def generate_path(*, date: datetime.date, bucket: str, category: str) -> str:
@@ -77,51 +78,109 @@ def load_files_from_json(file_path: str) -> list[dict[str, str]]:
         sys.exit(1)
 
 
+def _get_api_key(env: str) -> str:
+    var = 'OFFSETS_DB_API_KEY_PRODUCTION' if env == 'production' else 'OFFSETS_DB_API_KEY_STAGING'
+    key = os.environ.get(var)
+    if key is None:
+        raise ValueError(f'{var} environment variable not set')
+    return key
+
+
+def _request(method: str, url: str, headers: dict, **kwargs) -> httpx.Response:
+    try:
+        return httpx.request(method, url, headers=headers, timeout=30, **kwargs)
+    except httpx.ConnectError:
+        print(f'Error: could not connect to {url}')
+        print('Is the API server running?')
+        sys.exit(1)
+    except httpx.TimeoutException:
+        print(f'Error: request to {url} timed out after 30s')
+        sys.exit(1)
+
+
+def _poll_until_complete(
+    *,
+    base_url: str,
+    file_ids: list[int],
+    headers: dict,
+    initial_delay: float = 2.0,
+    max_delay: float = 30.0,
+    timeout: float = 600.0,
+) -> list[dict]:
+    """Poll file statuses with exponential backoff until all leave pending state."""
+    pending = set(file_ids)
+    results: dict[int, dict] = {}
+    deadline = time.monotonic() + timeout
+    delay = initial_delay
+
+    print(f'\nPolling status for {len(file_ids)} file(s)...')
+
+    while pending:
+        if time.monotonic() > deadline:
+            timed_out = [str(i) for i in pending]
+            print(f'Timed out waiting for file(s): {", ".join(timed_out)}')
+            sys.exit(1)
+
+        time.sleep(delay)
+        delay = min(delay * 2, max_delay)
+
+        for file_id in list(pending):
+            resp = _request('GET', f'{base_url.rstrip("/")}/{file_id}', headers=headers)
+            if not resp.is_success:
+                print(f'  [{file_id}] HTTP {resp.status_code} polling status — skipping')
+                continue
+            file = resp.json()
+            if file['status'] != 'pending':
+                pending.discard(file_id)
+                results[file_id] = file
+                icon = '✓' if file['status'] == 'success' else '✗'
+                error = f'  error: {file["error"]}' if file.get('error') else ''
+                print(
+                    f'  {icon} [{file_id}] {file["category"]:8s} {file["status"]:8s}  {file["url"]}{error}'
+                )
+
+    return list(results.values())
+
+
 def post_data_to_environment(
     *,
     env: str,
     url: str,
     files: list[dict[str, str]],
 ) -> None:
-    """Post file definitions to the API."""
-    # Get API key from environment
-    if env == 'production':
-        api_key = os.environ.get('OFFSETS_DB_API_KEY_PRODUCTION')
-        if api_key is None:
-            raise ValueError('OFFSETS_DB_API_KEY_PRODUCTION environment variable not set')
-    else:
-        api_key = os.environ.get('OFFSETS_DB_API_KEY_STAGING')
-        if api_key is None:
-            raise ValueError('OFFSETS_DB_API_KEY_STAGING environment variable not set')
-
     headers = {
         'accept': 'application/json',
         'Content-Type': 'application/json',
-        'X-API-KEY': api_key,
+        'X-API-KEY': _get_api_key(env),
     }
 
-    print(f'\nSending {len(files)} files to {url}:')
+    print(f'\nSending {len(files)} file(s) to {url}:')
     for file in files:
         print(f'- {file["category"]}: {file["url"]}')
 
-    timeout = 200  # seconds
-    try:
-        response = requests.post(url, headers=headers, data=json.dumps(files), timeout=timeout)
-    except requests.exceptions.ConnectionError:
-        print(f'\nFailed in {env}: could not connect to {url}')
-        print('Is the API server running?')
-        sys.exit(1)
-    except requests.exceptions.Timeout:
-        print(f'\nFailed in {env}: request to {url} timed out after {timeout} seconds')
-        sys.exit(1)
-
-    if response.ok:
-        print(f'\nSuccess in {env}:', response.json())
-    else:
+    response = _request('POST', url, headers=headers, json=files)
+    if not response.is_success:
         print(f'\nFailed in {env}: HTTP {response.status_code} {response.reason}')
         if body := response.text.strip():
             print(body)
         sys.exit(1)
+
+    queued = response.json()
+    file_ids = [f['id'] for f in queued]
+    print(f'Queued {len(file_ids)} file(s) with ids: {file_ids}')
+
+    results = _poll_until_complete(base_url=url, file_ids=file_ids, headers=headers)
+
+    failures = [f for f in results if f['status'] == 'failure']
+    if failures:
+        print(f'\n{len(failures)} file(s) failed in {env}:')
+        for f in failures:
+            print(f'  - [{f["id"]}] {f["url"]}')
+            if f.get('error'):
+                print(f'    {f["error"]}')
+        sys.exit(1)
+
+    print(f'\nAll {len(results)} file(s) processed successfully in {env}.')
 
 
 def main():

--- a/scripts/update_database.py
+++ b/scripts/update_database.py
@@ -104,22 +104,22 @@ def post_data_to_environment(
     for file in files:
         print(f'- {file["category"]}: {file["url"]}')
 
+    timeout = 200  # seconds
     try:
-        response = requests.post(url, headers=headers, data=json.dumps(files), timeout=100)
+        response = requests.post(url, headers=headers, data=json.dumps(files), timeout=timeout)
     except requests.exceptions.ConnectionError:
         print(f'\nFailed in {env}: could not connect to {url}')
         print('Is the API server running?')
         sys.exit(1)
     except requests.exceptions.Timeout:
-        print(f'\nFailed in {env}: request to {url} timed out after 30s')
+        print(f'\nFailed in {env}: request to {url} timed out after {timeout} seconds')
         sys.exit(1)
 
     if response.ok:
         print(f'\nSuccess in {env}:', response.json())
     else:
         print(f'\nFailed in {env}: HTTP {response.status_code} {response.reason}')
-        body = response.text.strip()
-        if body:
+        if body := response.text.strip():
             print(body)
         sys.exit(1)
 

--- a/scripts/update_database.py
+++ b/scripts/update_database.py
@@ -104,14 +104,23 @@ def post_data_to_environment(
     for file in files:
         print(f'- {file["category"]}: {file["url"]}')
 
-    # Send the request
-    response = requests.post(url, headers=headers, data=json.dumps(files))
+    try:
+        response = requests.post(url, headers=headers, data=json.dumps(files), timeout=100)
+    except requests.exceptions.ConnectionError:
+        print(f'\nFailed in {env}: could not connect to {url}')
+        print('Is the API server running?')
+        sys.exit(1)
+    except requests.exceptions.Timeout:
+        print(f'\nFailed in {env}: request to {url} timed out after 30s')
+        sys.exit(1)
 
-    # Log the response
     if response.ok:
         print(f'\nSuccess in {env}:', response.json())
     else:
-        print(f'\nFailed in {env}:', response.text)
+        print(f'\nFailed in {env}: HTTP {response.status_code} {response.reason}')
+        body = response.text.strip()
+        if body:
+            print(body)
         sys.exit(1)
 
 

--- a/scripts/update_database.py
+++ b/scripts/update_database.py
@@ -147,7 +147,7 @@ def post_data_to_environment(
     env: str,
     url: str,
     files: list[dict[str, str]],
-    post_timeout: float = 120,
+    post_timeout: float = 300,
 ) -> None:
     headers = {
         'accept': 'application/json',
@@ -172,8 +172,7 @@ def post_data_to_environment(
 
     results = _poll_until_complete(base_url=url, file_ids=file_ids, headers=headers)
 
-    failures = [f for f in results if f['status'] == 'failure']
-    if failures:
+    if failures := [f for f in results if f['status'] == 'failure']:
         print(f'\n{len(failures)} file(s) failed in {env}:')
         for f in failures:
             print(f'  - [{f["id"]}] {f["url"]}')


### PR DESCRIPTION
the clips parquet file stores tags as JSON-encoded strings (["additionality"]). fastparquet silently parsed these as Python lists; pyarrow returns them as strings. the ARRAY conversion lambda skipped strings, passing JSON directly to PostgreSQL COPY which rejected it

- #211 follow up 