### PR TITLE
classify staging seed failures before proceeding to prod

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -37,6 +37,8 @@ jobs:
       name: staging
       url: ${{ env.STAGING_URL }}
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'api') && github.event_name == 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'}}
+    outputs:
+      staging_seed_type: ${{ steps.classify-staging.outputs.type }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup AWS and pixi
@@ -47,7 +49,24 @@ jobs:
       - name: Deploy to Staging
         run: |
           flyctl deploy --remote-only --config fly.staging.toml
-          pixi run update-db-staging
+      - name: Seed Staging Database
+        id: seed-staging
+        continue-on-error: true
+        run: |
+          pixi run update-db-staging 2>&1 | tee /tmp/staging-output.txt
+          exit ${PIPESTATUS[0]}
+      - name: Classify staging failure
+        id: classify-staging
+        if: steps.seed-staging.outcome == 'failure'
+        run: |
+          if grep -q "file paths don't exist" /tmp/staging-output.txt; then
+            echo "type=missing_data" >> $GITHUB_OUTPUT
+          else
+            echo "type=unexpected" >> $GITHUB_OUTPUT
+          fi
+      - name: Fail on unexpected staging error
+        if: steps.classify-staging.outputs.type == 'unexpected'
+        run: exit 1
 
   deploy-production:
     name: deploy production
@@ -75,6 +94,52 @@ jobs:
       - name: Deploy to Production
         run: |
           flyctl deploy --remote-only --config fly.prod.toml
+      - name: Notify Slack on staging missing data
+        if: needs.deploy-staging.outputs.staging_seed_type == 'missing_data'
+        uses: slackapi/slack-github-action@v3.0.2
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "C06CXEYKMBP",
+              "attachments": [
+                {
+                  "color": "#ff9900",
+                  "blocks": [
+                    {
+                      "type": "header",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "Staging DB Seed Skipped ⚠️ (Production continuing)"
+                      }
+                    },
+                    {
+                      "type": "section",
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Reason:*\nStaging S3 data unavailable"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Time:*\n${{ steps.time.outputs.date }} UTC"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "section",
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Details URL:*\n🔍 <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Workflow Run>"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
       - name: Notify Slack on Failure
         if: failure()
         uses: slackapi/slack-github-action@v3.0.2

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -39,6 +39,7 @@ jobs:
     if: ${{ (contains(github.event.pull_request.labels.*.name, 'api') && github.event_name == 'pull_request') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'}}
     outputs:
       staging_seed_type: ${{ steps.classify-staging.outputs.type }}
+      staging_seed_reason: ${{ steps.classify-staging.outputs.reason }}
     steps:
       - uses: actions/checkout@v6
       - name: Setup AWS and pixi
@@ -61,8 +62,10 @@ jobs:
         run: |
           if grep -q "file paths don't exist" /tmp/staging-output.txt; then
             echo "type=missing_data" >> $GITHUB_OUTPUT
+            echo "reason=$(grep 'ValueError:' /tmp/staging-output.txt | tail -1)" >> $GITHUB_OUTPUT
           else
             echo "type=unexpected" >> $GITHUB_OUTPUT
+            echo "reason=$(tail -1 /tmp/staging-output.txt)" >> $GITHUB_OUTPUT
           fi
       - name: Fail on unexpected staging error
         if: steps.classify-staging.outputs.type == 'unexpected'
@@ -119,7 +122,7 @@ jobs:
                       "fields": [
                         {
                           "type": "mrkdwn",
-                          "text": "*Reason:*\nStaging S3 data unavailable"
+                          "text": "*Reason:*\n${{ needs.deploy-staging.outputs.staging_seed_reason }}"
                         },
                         {
                           "type": "mrkdwn",

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -50,8 +50,10 @@ jobs:
         run: |
           if grep -q "file paths don't exist" /tmp/staging-output.txt; then
             echo "type=missing_data" >> $GITHUB_OUTPUT
+            echo "reason=$(grep 'ValueError:' /tmp/staging-output.txt | tail -1)" >> $GITHUB_OUTPUT
           else
             echo "type=unexpected" >> $GITHUB_OUTPUT
+            echo "reason=$(tail -1 /tmp/staging-output.txt)" >> $GITHUB_OUTPUT
           fi
 
       - name: Notify Slack on staging missing data
@@ -79,7 +81,7 @@ jobs:
                       "fields": [
                         {
                           "type": "mrkdwn",
-                          "text": "*Reason:*\nStaging S3 data unavailable"
+                          "text": "*Reason:*\n${{ steps.classify-staging.outputs.reason }}"
                         },
                         {
                           "type": "mrkdwn",

--- a/.github/workflows/update-db.yaml
+++ b/.github/workflows/update-db.yaml
@@ -41,10 +41,21 @@ jobs:
         id: seed-staging
         continue-on-error: true
         run: |
-          pixi run update-db-staging
+          pixi run update-db-staging 2>&1 | tee /tmp/staging-output.txt
+          exit ${PIPESTATUS[0]}
 
-      - name: Notify Slack on Staging Failure
-        if: steps.seed-staging.outcome == 'failure' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+      - name: Classify staging failure
+        id: classify-staging
+        if: steps.seed-staging.outcome == 'failure'
+        run: |
+          if grep -q "file paths don't exist" /tmp/staging-output.txt; then
+            echo "type=missing_data" >> $GITHUB_OUTPUT
+          else
+            echo "type=unexpected" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Notify Slack on staging missing data
+        if: steps.classify-staging.outputs.type == 'missing_data' && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
         uses: slackapi/slack-github-action@v3.0.2
         with:
           method: chat.postMessage
@@ -68,7 +79,7 @@ jobs:
                       "fields": [
                         {
                           "type": "mrkdwn",
-                          "text": "*GH event:*\n${{ github.event_name }}"
+                          "text": "*Reason:*\nStaging S3 data unavailable"
                         },
                         {
                           "type": "mrkdwn",
@@ -89,6 +100,10 @@ jobs:
                 }
               ]
             }
+
+      - name: Fail on unexpected staging error
+        if: steps.classify-staging.outputs.type == 'unexpected'
+        run: exit 1
 
       - name: Seed Production Database
         if:


### PR DESCRIPTION
known-safe failures (S3 data unavailable in test bucket) send an orange slack alert and let production continue. Unexpected failures explicitly exit 1 to block production and trigger the existing red alert