### PR TITLE
fix(docker): pin pixi to v0.70.0 via installer instead of latest image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 # Build stage using pixi
-FROM ghcr.io/prefix-dev/pixi:latest AS build
+FROM ubuntu:24.04 AS build
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
-# Install git and ca-certificates (needed for git+https:// dependencies in pyproject.toml)
+# Install git, ca-certificates, and curl (needed for pixi installer and git+https:// deps)
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends git ca-certificates && \
+    apt-get install -y --no-install-recommends git ca-certificates curl && \
     rm -rf /var/lib/apt/lists/*
+
+# Install pixi — pin to the same version used to generate pixi.lock to avoid
+# lock-file-not-up-to-date failures when the ghcr.io/prefix-dev/pixi:latest image lags behind.
+RUN curl -fsSL https://pixi.sh/install.sh | PIXI_VERSION=v0.70.0 bash
+ENV PATH="/root/.pixi/bin:$PATH"
 
 # Copy source code, pixi.toml and pixi.lock to the container
 WORKDIR /app


### PR DESCRIPTION
ghcr.io/prefix-dev/pixi:latest was serving 0.69.0 while pixi.lock was generated with 0.70.0. The 0.70 release changed lock-file metadata format (v3 repodata/matchspec support), causing 0.69.0 to reject the lock file with "lock-file not up-to-date with the workspace"

Using the installer with PIXI_VERSION decouples Docker builds from the image release schedule. Update PIXI_VERSION and regenerate pixi.lock together when upgrading pixi
